### PR TITLE
feature/se0yu-saveComment 댓글 작성 기능 추가

### DIFF
--- a/src/main/java/org/example/newsfeed/controller/CommentController.java
+++ b/src/main/java/org/example/newsfeed/controller/CommentController.java
@@ -1,0 +1,46 @@
+package org.example.newsfeed.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.newsfeed.dto.comment.CommentRequestDto;
+import org.example.newsfeed.dto.comment.CommentResponseDto;
+import org.example.newsfeed.service.CommentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/newsfeeds/{newsfeedsId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    //댓글 작성 기능
+    @PostMapping
+    public ResponseEntity<Void> saveComment(
+            @PathVariable Long newsfeedsId,
+//            HttpServletRequest httpServletRequest,
+            @Valid @RequestBody CommentRequestDto requsetDto
+    ){
+
+        //현재 userId 는 테스트용도 - 후에 수정할 예정
+        /*
+        테스트 당시 board 기능이 구현되지 않아 console에서 하단 쿼리문 실행 후 테스트함
+
+        INSERT INTO boards(title, contents,user_id,created_at)
+        VALUES('타이틀','내용',1,'2025-04-08');
+
+        localhost:8080/newsfeeds/1/comments
+
+        {
+        "comments" : "댓글3"
+        }
+
+         */
+        CommentResponseDto responseDto = commentService.saveComment(newsfeedsId,1L,requsetDto);
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/org/example/newsfeed/dto/comment/CommentRequestDto.java
+++ b/src/main/java/org/example/newsfeed/dto/comment/CommentRequestDto.java
@@ -1,0 +1,15 @@
+package org.example.newsfeed.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentRequestDto {
+
+    @NotBlank(message = "댓글 내용은 비울 수 없습니다.")
+    @Size(max = 500, message = "댓글은 500자를 초과할 수 없습니다.")
+    private final String comments;
+}

--- a/src/main/java/org/example/newsfeed/dto/comment/CommentResponseDto.java
+++ b/src/main/java/org/example/newsfeed/dto/comment/CommentResponseDto.java
@@ -1,0 +1,34 @@
+package org.example.newsfeed.dto.comment;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.newsfeed.entity.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponseDto {
+
+    private final Long id;
+
+    private final Long boardId;
+
+    private final String nickname;
+
+    private final String comments;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private final LocalDateTime createdAt;
+
+    public static CommentResponseDto toDto(Comment comment) {
+        return new CommentResponseDto(
+                comment.getId(),
+                comment.getBoard().getId(),
+                comment.getUser().getNickname(),
+                comment.getComments(),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/newsfeed/entity/Comment.java
+++ b/src/main/java/org/example/newsfeed/entity/Comment.java
@@ -27,4 +27,9 @@ public class Comment extends BaseEntity{
     @NotBlank(message = "댓글 내용이 비어있습니다")
     private String comments;
 
+    public Comment(User user, Board board,String comments){
+    this.user = user;
+    this.board = board;
+    this.comments = comments;
+    }
 }

--- a/src/main/java/org/example/newsfeed/service/CommentService.java
+++ b/src/main/java/org/example/newsfeed/service/CommentService.java
@@ -1,0 +1,41 @@
+package org.example.newsfeed.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.newsfeed.dto.comment.CommentRequestDto;
+import org.example.newsfeed.dto.comment.CommentResponseDto;
+import org.example.newsfeed.entity.Board;
+import org.example.newsfeed.entity.Comment;
+import org.example.newsfeed.entity.User;
+import org.example.newsfeed.repository.BoardRepository;
+import org.example.newsfeed.repository.CommentRepository;
+import org.example.newsfeed.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    //댓글 작성 기능
+    @Transactional
+    public CommentResponseDto saveComment(Long newsfeedsId, Long userId, CommentRequestDto requestDto){
+
+        //해당 게시글, 작성자 관련 데이터 호출
+        //관련 예외 추가되면 수정할 예정
+        User user = userRepository.findById(userId)
+                .orElseThrow(()->new ResponseStatusException(HttpStatus.NOT_FOUND,"존재하지 않는 회원입니다."));
+        Board board = boardRepository.findById(newsfeedsId)
+                .orElseThrow(()->new ResponseStatusException(HttpStatus.NOT_FOUND,"존재하지 않는 게시글입니다."));;
+
+        Comment comment = new Comment(user, board,requestDto.getComments());
+        Comment savedComment = commentRepository.save(comment);
+
+        return CommentResponseDto.toDto(savedComment);
+    }
+}


### PR DESCRIPTION
미구현된 기능이 있어 테스트 코드를 넣어놨습니다.
후에 수정 예정이며 테스트 방법은 CommentController의 주석을 참고해주십시오.
Serivce 예외 처리도 후에 수정할 예정입니다.

댓글 최대 길이 500자 제한을 추가했습니다.

CommentResponseDto 의 toDto는 board에서 댓글을 조회하는 용도입니다.
이 부분 확인 부탁 드립니다.